### PR TITLE
docs: Update demo video duration and simplify video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ Note: This tool works in test, but exercise caution with live/prod PACS and test
 
 <div align="center">
 
-[![DICOM Fabricator Demo - Click to Watch](https://img.youtube.com/vi/8QwM6aQ1h6A/0.jpg)](https://flatmapit-com-videos.s3.amazonaws.com/20250903DicomFab.mov)
 
-**[▶️ Watch Demo Video (5 minutes)](https://flatmapit-com-videos.s3.amazonaws.com/20250903DicomFab.mov)**
+**[▶️ Watch Demo Video (2 minutes)](https://flatmapit-com-videos.s3.amazonaws.com/20250903DicomFab.mov)**
 
 *Complete walkthrough of DICOM Fabricator features and workflows*
 


### PR DESCRIPTION
## Documentation Update

### 🎥 Video Section Improvements

#### Duration Correction
- **Updated Duration**: Changed from '5 minutes' to '2 minutes' for accurate video length
- **Accurate Information**: Video duration now reflects actual content length

#### Layout Simplification
- **Simplified Layout**: Removed redundant thumbnail image line for cleaner presentation
- **Cleaner Design**: Streamlined video section without duplicate elements
- **Better UX**: More focused call-to-action with correct timing information

### 📋 Changes Summary
- Updated video duration from 5 minutes to 2 minutes
- Removed redundant thumbnail image line
- Simplified video section layout
- Improved user experience with accurate timing

This update provides users with accurate video duration information
and a cleaner, more focused video section layout.